### PR TITLE
Re-Add nosplash cmdline option

### DIFF
--- a/sgdm3/src/gui/MyBusyInfo.cpp
+++ b/sgdm3/src/gui/MyBusyInfo.cpp
@@ -47,7 +47,12 @@ void MyBusyInfo::Increment(void)
 	{
 		wxASSERT_MSG( (!m_pBusyInfo), _T("Coding Error") );
 		wxASSERT_MSG( (!m_pDisabler), _T("Coding Error") );
-		m_pBusyInfo = new wxBusyInfo("Please wait...");
+		
+		gui_app * pApp = static_cast<gui_app *>(wxTheApp);
+		if (!pApp->getCmdLineArgs().bNoSplash)
+		{
+			m_pBusyInfo = new wxBusyInfo("Please wait...");
+		}
 		m_pDisabler = new wxWindowDisabler(true);
 	}
 	else
@@ -73,8 +78,11 @@ void MyBusyInfo::Decrement(void)
 
 		delete m_pDisabler;
 		m_pDisabler = NULL;
-		delete m_pBusyInfo;
-		m_pBusyInfo = NULL;
+		if (m_pBusyInfo)
+		{
+			delete m_pBusyInfo;
+			m_pBusyInfo = NULL;
+		}
 	}
 	else
 	{

--- a/sgdm3/src/gui/cl_args.cpp
+++ b/sgdm3/src/gui/cl_args.cpp
@@ -22,6 +22,7 @@ cl_args::cl_args(void)
 	bTitle[2]    = false;
 	bResult      = false;
 	bCaption     = false;
+	bNoSplash    = false;
 
 	nrParams     = 0;
 

--- a/sgdm3/src/gui/cl_args.h
+++ b/sgdm3/src/gui/cl_args.h
@@ -32,6 +32,7 @@ public:
 	bool		bTitle[3];			// --title[123]
 	bool		bResult;			// --result
 	bool		bCaption;			// --caption
+	bool		bNoSplash;			// --nosplash
 
 	int			nrParams;			// how many pathnames they gave
 

--- a/sgdm3/src/gui/gui_app.h
+++ b/sgdm3/src/gui/gui_app.h
@@ -54,6 +54,8 @@ public:
 
 	wxString		formatArgvForSupportMessage(void);
 
+	const cl_args &	getCmdLineArgs(void) const { return m_cl_args; }
+
 private:
 	bool			_OnInit_cl_args(void);
 	void			_cleanup(void);

--- a/sgdm3/src/gui/gui_app__cl_args.cpp
+++ b/sgdm3/src/gui/gui_app__cl_args.cpp
@@ -116,8 +116,8 @@ void gui_app::OnInitCmdLine(wxCmdLineParser & parser)
 	{ wxCMD_LINE_SWITCH, _("MERGE"),	NULL,			NULL,														wxCMD_LINE_VAL_NONE },
 	{ wxCMD_LINE_SWITCH, _("m"),		_("merge"),		_("Run 'Merge to Center Panel' after loading files."),		wxCMD_LINE_VAL_NONE },
 	{ wxCMD_LINE_SWITCH, _("M"),		_("MERGE"),		_("Run 'Merge to Center Panel' after loading files."),		wxCMD_LINE_VAL_NONE },
-	{ wxCMD_LINE_SWITCH, _("nosplash"),_("nosplash"),	_("No splash screen [DEPRECATED]."),						wxCMD_LINE_VAL_NONE },
-	{ wxCMD_LINE_SWITCH, _("NOSPLASH"),_("NOSPLASH"),	_("No splash screen [DEPRECATED]."),						wxCMD_LINE_VAL_NONE },
+	{ wxCMD_LINE_SWITCH, _("nosplash"),_("nosplash"),	_("No splash screen."),								wxCMD_LINE_VAL_NONE },
+	{ wxCMD_LINE_SWITCH, _("NOSPLASH"),_("NOSPLASH"),	_("No splash screen."),								wxCMD_LINE_VAL_NONE },
 	{ wxCMD_LINE_OPTION, _("result"),	NULL,			NULL,														wxCMD_LINE_VAL_STRING,	wxCMD_LINE_NEEDS_SEPARATOR },
 	{ wxCMD_LINE_OPTION, _("RESULT"),	NULL,			NULL,														wxCMD_LINE_VAL_STRING,	wxCMD_LINE_NEEDS_SEPARATOR },
 	{ wxCMD_LINE_OPTION, _("r"),		_("result"),	_("Alternate pathname for saving 3-way merge result."),		wxCMD_LINE_VAL_STRING,	wxCMD_LINE_NEEDS_SEPARATOR },
@@ -198,6 +198,9 @@ bool gui_app::OnCmdLineParsed(wxCmdLineParser & parser)
 							   || parser.Found(_T("R"),&m_cl_args.result)     ||  parser.Found(_T("RESULT"),&m_cl_args.result) );
 	m_cl_args.bCaption     = (    parser.Found(_T("c"),&m_cl_args.caption)    ||  parser.Found(_T("caption"),&m_cl_args.caption)
 							   || parser.Found(_T("C"),&m_cl_args.caption)    ||  parser.Found(_T("CAPTION"),&m_cl_args.caption) );
+
+	m_cl_args.bNoSplash    = (    parser.Found(_T("nosplash"))
+							   || parser.Found(_T("NOSPLASH")) );
 
 	m_cl_args.bDumpDiffs   = (    parser.Found(_T("d"),&m_cl_args.diffOutput) ||  parser.Found(_T("diff"),&m_cl_args.diffOutput)
 							   || parser.Found(_T("D"),&m_cl_args.diffOutput) ||  parser.Found(_T("DIFF"),&m_cl_args.diffOutput) );
@@ -543,10 +546,10 @@ wxString gui_app::_makeUsageString(void) const
 	strUsage += _("    /t1=STRING, /title1=STRING, --title1=STRING\n");
 	strUsage += _("    /t2=STRING, /title2=STRING, --title2=STRING\n");
 	strUsage += _("    /t3=STRING, /title3=STRING, --title3=STRING\n");
+	strUsage += _("    /nosplash, --nosplash\n");
 
 //	strUsage += _("    /ro1, --ro1\n");
 //	strUsage += _("    /ro3, --ro3\n");
-//	strUsage += _("    /nosplash, --nosplash\n");
 
 	strUsage += _("\n");
 	strUsage += _("Batch Options:\n");


### PR DESCRIPTION
(Re) add the --nosplash commandline option
This now prevents the modal "Please Wait" window

Why?
Because when I compare 2 large folders (for example), this window can hang about for a long while, obscuring the centre of my screen and preventing me from working whilst I wait for DiffMerge to be ready